### PR TITLE
New '/product/recommendations' API endpoint

### DIFF
--- a/sm-core-model/src/main/java/com/salesmanager/core/model/catalog/product/Product.java
+++ b/sm-core-model/src/main/java/com/salesmanager/core/model/catalog/product/Product.java
@@ -19,6 +19,8 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 import javax.persistence.Temporal;
@@ -36,6 +38,7 @@ import com.salesmanager.core.model.catalog.product.availability.ProductAvailabil
 import com.salesmanager.core.model.catalog.product.description.ProductDescription;
 import com.salesmanager.core.model.catalog.product.image.ProductImage;
 import com.salesmanager.core.model.catalog.product.manufacturer.Manufacturer;
+import com.salesmanager.core.model.catalog.product.price.ProductPrice;
 import com.salesmanager.core.model.catalog.product.relationship.ProductRelationship;
 import com.salesmanager.core.model.catalog.product.type.ProductType;
 import com.salesmanager.core.model.common.audit.AuditListener;
@@ -98,6 +101,10 @@ public class Product extends SalesManagerEntity<Long, Product> implements Audita
 		
 	})
 	private Set<Category> categories = new HashSet<Category>();
+	
+	@OneToOne(cascade = CascadeType.ALL)
+	@PrimaryKeyJoinColumn
+	private ProductPrice price;
 	
 	@Column(name="DATE_AVAILABLE")
 	@Temporal(TemporalType.TIMESTAMP)

--- a/sm-core-model/src/main/java/com/salesmanager/core/model/catalog/product/ProductCriteria.java
+++ b/sm-core-model/src/main/java/com/salesmanager/core/model/catalog/product/ProductCriteria.java
@@ -24,6 +24,8 @@ public class ProductCriteria extends Criteria {
 	
 	private Long ownerId = null;
 
+	private boolean recommended;
+	
 	public String getProductName() {
 		return productName;
 	}
@@ -97,6 +99,12 @@ public class ProductCriteria extends Criteria {
 		this.ownerId = ownerId;
 	}
 
+	public boolean isRecommended() {
+		return recommended;
+	}
 
+	public void setRecommended(boolean recommended) {
+		this.recommended = recommended;
+	}
 
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java
@@ -27,6 +27,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProductRepositoryImpl.class);
 	
+	private final String RECOMMENDED_WHERE_CLAUSE = " and price.productPriceSpecialAmount is not null and price.productPriceSpecialAmount <= price.productPriceAmount * 0.8";
+	
     @PersistenceContext
     private EntityManager em;
 
@@ -639,6 +641,11 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 			}
 		}
 
+		if (criteria.isRecommended()) {
+			countBuilderSelect.append(" INNER JOIN p.price price");
+			countBuilderWhere.append(RECOMMENDED_WHERE_CLAUSE);
+		}
+
 		Query countQ = this.em.createQuery(
 				countBuilderSelect.toString() + countBuilderWhere.toString());
 
@@ -742,6 +749,9 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 		
 		qs.append(" left join fetch p.relationships pr");
 		
+		if (criteria.isRecommended()) {
+			qs.append("inner join p.price price ");
+		}
 
 		qs.append(" where merch.id=:mId");
 		if(criteria.getLanguage() != null && !criteria.getLanguage().equals("_all")) {
@@ -798,6 +808,11 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 			}
 
 		}
+
+		if (criteria.isRecommended()) {
+			qs.append(RECOMMENDED_WHERE_CLAUSE);
+		}
+		
 		qs.append(" order by p.sortOrder asc");
 
 

--- a/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/product/ProductApi.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/product/ProductApi.java
@@ -425,6 +425,50 @@ public class ProductApi {
     }
   }
 
+  @RequestMapping(value = "/products/recommended", method = RequestMethod.GET)
+  @ResponseBody
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = "store", dataType = "String", defaultValue = "DEFAULT"),
+      @ApiImplicitParam(name = "lang", dataType = "String", defaultValue = "en")
+  })
+  public ReadableProductList listRecommended(
+      @RequestParam(value = "lang", required = false) String lang,
+      @RequestParam(value = "category", required = true) Long category,
+      @ApiIgnore MerchantStore merchantStore,
+      @ApiIgnore Language language,
+      HttpServletRequest request,
+      HttpServletResponse response)
+      throws Exception {
+
+    ProductCriteria criteria = new ProductCriteria();
+    
+    if (lang != null) {
+      criteria.setLanguage(lang);
+    } else {
+      criteria.setLanguage(language.getCode());
+    }
+    if (category != null) {
+      List<Long> categoryIds = new ArrayList<Long>();
+      categoryIds.add(category);
+      criteria.setCategoryIds(categoryIds);
+    }
+    criteria.setRecommended(true);
+
+    try {
+      return productFacade.getProductListsByCriterias(merchantStore, language, criteria);
+
+    } catch (Exception e) {
+
+      LOGGER.error("Error while filtering products product", e);
+      try {
+        response.sendError(503, "Error while filtering products " + e.getMessage());
+      } catch (Exception ignore) {
+      }
+
+      return null;
+    }
+  }
+  
   /**
    * API for getting a product
    *


### PR DESCRIPTION
Changes:

- Added new method to `ProductAPI.java` to handle new `/products/recommended` endpoint with required `category` parameter.
- Added new `recommended` field to `ProductCriteria.java`.
- Added logic to `ProductRepositoryImpl.java` to return products that are discounted by at least 20%. 
- To support changes to an HQL query in `ProductRepositoryImpl.java`, I updated `Product.java` to contain a one-to-one mapping to `ProductPrice.java`.

Future improvements might include:
- Merging `list()` and `listRecommended()` in `ProductRepositoryImpl.java` to eliminate redundant code.
- Making the 20% threshold configurable, so it could be 10% or 30% in the future.
- Generalizing the meaning of "recommended" further so it could be anything, e.g. items on clearance company wants to get rid of ASAP. Changes would be in configuration so that a Java build/deploy would not be required for them to take effect.

Finally, I believe there is a bug wherein the `category` parameter doesn't properly filter the API results. http://localhost:8080/api/v1/products and http://localhost:8080/api/v1/products?category=1 and http://localhost:8080/api/v1/products?category=2 all return the same JSON document. I had originally cloned and made the changes on https://github.com/shopizer-ecommerce/shopizer, as opposed to https://github.com/rocketinsights/shopizer and had not encountered this issue. This requires further investigation.



